### PR TITLE
Drop project/version API calls

### DIFF
--- a/pypi/pypi.go
+++ b/pypi/pypi.go
@@ -145,9 +145,7 @@ func (p *PackageIndex) GetLatest(projectName string) (pkg Package, err error) {
 }
 
 func (p *PackageIndex) GetRelease(projectName string, version string) (pkg Package, err error) {
-	endpoint := fmt.Sprintf("pypi/%s/%s/json", projectName, version)
-	pkg, err = p.packageReq(endpoint)
-	return pkg, nil
+	return p.GetLatest(projectName)
 }
 
 func downloadReleaseFile(dst, url string) error {


### PR DESCRIPTION
> Previously this response included the releases key, which had the URLs
for all files for every release of this project on PyPI. Due to
    stability concerns, this had to be removed from the release specific
    page, which now ONLY serves data specific to that release.

    To access all files, you should preferrably use the simple API, or
    otherwise use the non versioned json api at
    /pypi/<project_name>/json.